### PR TITLE
 Fix types in createOrder and validateSignature

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -89,9 +89,10 @@ class ApiClient
      * @param object $order The Order object.
      * @param object $customer The Customer object.
      *
-     * @return string Result data or error message.
+     * @return string|object Response data.
+     * @throws Exception
      */
-    public function createOrder($orderData, $customerData)
+    public function createOrder($orderData, $customerData): ?object
     {
         // Build body
         $body = [

--- a/src/Webhook/Event.php
+++ b/src/Webhook/Event.php
@@ -70,7 +70,9 @@ class Event
      * Verify the incoming webhook notification to make sure it is legit.
      *
      * @param string $webhooksSecret The Webhooks Secret from Utrust Merchant dashboard.
+     *
      * @return bool
+     * @throws Exception
      */
     public function validateSignature($webhooksSecret)
     {


### PR DESCRIPTION
Why?
* `createOrder` and `validateSignature` can throw an Exception and that's not documented

What?
*  Adds `@throws Exception`