### PR TITLE
Add missing params checks to Event

### DIFF
--- a/src/Webhook/Event.php
+++ b/src/Webhook/Event.php
@@ -20,6 +20,16 @@ class Event
             throw new \Exception('Event_type is missing on the payload.' . print_r($this->payload, true));
         }
 
+        // Make sure it has amount
+        if (!isset($this->payload->resource->amount)) {
+            throw new \Exception('Amount is missing on the payload.' . print_r($this->payload, true));
+        }
+
+        // Make sure it has currency
+        if (!isset($this->payload->resource->currency)) {
+            throw new \Exception('Currency is missing on the payload.' . print_r($this->payload, true));
+        }
+
         // Make sure it has reference
         if (!isset($this->payload->resource->reference)) {
             throw new \Exception('Reference is missing on the payload.' . print_r($this->payload, true));
@@ -37,16 +47,6 @@ class Event
     }
 
     /**
-     * Gets Order Reference data
-     *
-     * @return string Order Reference data.
-     */
-    public function getOrderReference()
-    {
-        return $this->payload->resource->reference;
-    }
-
-    /**
      * Gets Order amount
      *
      * @return string Order amount.
@@ -54,6 +54,26 @@ class Event
     public function getOrderAmount()
     {
         return $this->payload->resource->amount;
+    }
+
+    /**
+     *
+     * Gets Order currency
+     * @return string Order currency.
+     */
+    public function getOrderCurrency()
+    {
+        return $this->payload->resource->currency;
+    }
+
+    /**
+     * Gets Order Reference data
+     *
+     * @return string Order Reference data.
+     */
+    public function getOrderReference()
+    {
+        return $this->payload->resource->reference;
     }
 
     /**

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -25,6 +25,26 @@ class WebhookTest extends TestCase
         $event = new Event($invalidPayload);
     }
 
+    public function testInvalidPayloadMissingAmount(): void
+    {
+        $invalidPayload = "{ \"event_type\": \"ORDER.PAYMENT.CANCELLED\", \"resource\": { \"currency\": \"EUR\", \"reference\": \"REF-12345678\" }, \"signature\": \"bb32374545004b5f4a1264a8e8e78e3357e27a35a8a3b334fe1a2a47b60a35ba\", \"state\": \"cancelled\" }";
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Amount is missing on the payload.');
+
+        $event = new Event($invalidPayload);
+    }
+
+    public function testInvalidPayloadMissingCurrency(): void
+    {
+        $invalidPayload = "{ \"event_type\": \"ORDER.PAYMENT.CANCELLED\", \"resource\": { \"amount\": \"0.99\", \"reference\": \"REF-12345678\" }, \"signature\": \"bb32374545004b5f4a1264a8e8e78e3357e27a35a8a3b334fe1a2a47b60a35ba\", \"state\": \"cancelled\" }";
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Currency is missing on the payload.');
+
+        $event = new Event($invalidPayload);
+    }
+
     public function testInvalidPayloadMissingReference(): void
     {
         $invalidPayload = "{ \"event_type\": \"ORDER.PAYMENT.CANCELLED\", \"resource\": { \"amount\": \"0.99\", \"currency\": \"EUR\" }, \"signature\": \"1234-this-is-an-invalid-signature-1234\", \"state\": \"cancelled\" }";


### PR DESCRIPTION
Why?
* We are missing to check the Amount and Currency on the event payload, if they don't exist it should throw an Expection

What?
* Adds Exceptions when Amount or Currency doesn't exist
* Adds tests